### PR TITLE
[ADD] purchase_reporting_weight

### DIFF
--- a/purchase_reporting_weight/README.rst
+++ b/purchase_reporting_weight/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=====================================
+Weights in the purchase analysis view
+=====================================
+
+This module adds the measure "Weight" in the purchase analysis view. This is
+caught from 2 possible sources:
+
+* If the UoM of the product is one of the category "Weight", the value is taken
+  from the ordered quantity.
+* If the UoM of the product is another, then the weight is taken from the
+  weight field of the product multiply by the ordered quantity.
+
+Usage
+=====
+
+#. Go to *Purchases > Reports*.
+#. Add the "Weight" measure from your "Measures" dropdown in your analysis.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/141/9.0
+
+Known issues / Roadmap
+======================
+
+* The weight quantity is expressed in the unit of measure of the product,
+  so if you have several weight UoMs across your products, the global sum won't
+  make sense.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_reporting_weight/__init__.py
+++ b/purchase_reporting_weight/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import reports

--- a/purchase_reporting_weight/__openerp__.py
+++ b/purchase_reporting_weight/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Weights in the purchase analysis view',
+    'version': '9.0.1.0.0',
+    'author': 'Tecnativa,'
+              'Odoo Community Association (OCA)',
+    'category': 'Inventory, Logistics, Warehousing',
+    'license': 'AGPL-3',
+    'website': 'https://www.tecnativa.com',
+    'depends': [
+        'purchase',
+    ],
+    'installable': True,
+}

--- a/purchase_reporting_weight/i18n/es.po
+++ b/purchase_reporting_weight/i18n/es.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_reporting_weight
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-01-20 09:24+0000\n"
+"PO-Revision-Date: 2017-01-20 09:24+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_reporting_weight
+#: model:ir.model,name:purchase_reporting_weight.model_purchase_report
+msgid "Purchases Orders"
+msgstr "Pedidos de compras"
+
+#. module: purchase_reporting_weight
+#: model:ir.model.fields,field_description:purchase_reporting_weight.field_purchase_report_weight
+msgid "Weight"
+msgstr "Peso"
+

--- a/purchase_reporting_weight/reports/__init__.py
+++ b/purchase_reporting_weight/reports/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import purchase_report

--- a/purchase_reporting_weight/reports/purchase_report.py
+++ b/purchase_reporting_weight/reports/purchase_report.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import fields, models, tools
+import openerp.addons.decimal_precision as dp
+
+
+class PurchaseReport(models.Model):
+    _inherit = "purchase.report"
+
+    weight = fields.Float(digits=dp.get_precision('Stock Weight'))
+
+    def _select(self):
+        return """
+            , CASE
+                WHEN u.category_id = imd.res_id
+                THEN SUM(l.product_qty / u.factor * u2.factor)
+                ELSE SUM(p.weight * l.product_qty / u.factor * u2.factor)
+            END AS weight
+            """
+
+    def _from(self):
+        return """
+            JOIN ir_model_data imd
+                ON (imd.module = 'product' AND
+                    imd.name = 'product_uom_categ_kgm')
+            """
+
+    def _group_by(self):
+        return ", p.weight, u.category_id, imd.res_id"
+
+    def init(self, cr):
+        """Inject parts in the query with this hack, fetching the query and
+        recreating it. Query is returned all in upper case and with final ';'.
+        """
+        super(PurchaseReport, self).init(cr)
+        cr.execute("SELECT pg_get_viewdef(%s, true)", (self._table,))
+        view_def = cr.fetchone()[0]
+        view_def = view_def.replace(
+            "FROM purchase_order_line",
+            "{} FROM purchase_order_line".format(self._select()),
+        )
+        view_def = view_def.replace(
+            "GROUP BY", " {} GROUP BY".format(self._from()),
+        )
+        if view_def[-1] == ';':
+            view_def = view_def[:-1]
+        view_def += self._group_by()
+        # Re-create view
+        tools.drop_view_if_exists(cr, self._table)
+        cr.execute("create or replace view {} as ({})".format(
+            self._table, view_def,
+        ))


### PR DESCRIPTION
Weights in the purchase analysis view
=====================================

This module adds the measure "Weight" in the purchase analysis view. This is caught from 2 possible sources:

* If the UoM of the product is one of the category "Weight", the value is taken from the ordered quantity.
* If the UoM of the product is another, then the weight is taken from the weight field of the product multiply by the ordered quantity.

Usage
=====

* Go to *Purchases > Reports*.
* Add the "Weight" measure from your "Measures" dropdown in your analysis.

Known issues / Roadmap
======================

* The weight quantity is expressed in the unit of measure of the product, so if you have several weight UoMs across your products, the global sum won't make sense.