### PR TITLE
Unbreak the table

### DIFF
--- a/purchase_comment_template/views/report_purchaseorder.xml
+++ b/purchase_comment_template/views/report_purchaseorder.xml
@@ -3,55 +3,30 @@
 
     <template id="report_purchaseorder_document_comments"
       inherit_id="purchase.report_purchaseorder_document">
-      <xpath expr="//div[hasclass('oe_structure')][1]" position="before">
-        <template id="purchase_css" inherit_id="web.layout">
-            <xpath expr="//head" position="inside">
-                <link rel="stylesheet"
-                    href="/purchase_comment_template/static/src/css/purchase.css" />
-            </xpath>
-        </template>
-      </xpath>
       <xpath expr="//table[hasclass('table-sm')]" position="before">
         <p t-if="o.note1">
           <span t-field="o.note1"/>
         </p>
       </xpath>
-      <xpath expr="//tr[@t-as='line']" position="replace">
+      <xpath expr="//tbody" position="inside">
         <t t-foreach="o.order_line" t-as="line">
-            <tr>
-                <td>
-                    <span t-field="line.name"/>
-                </td>
-                <td>
-                    <span t-esc="', '.join(map(lambda x: x.name, line.taxes_id))"/>
-                </td>
-                <td class="text-center">
-                    <span t-field="line.date_planned"/>
-                </td>
-                <td class="text-right">
-                    <span t-field="line.product_qty"/>
-                    <span t-field="line.product_uom.name" groups="uom.group_uom"/>
-                </td>
-                <td class="text-right">
-                    <span t-field="line.price_unit"/>
-                </td>
-                <td class="text-right">
-                    <span t-field="line.price_subtotal"
-                        t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                </td>
-            </tr>
+        </t>
+      </xpath>
+      <xpath expr="//t[@t-as='line']" position="inside">
+        <xpath expr="//tr[@t-as='line']" position="move"/>
+      </xpath>
+      <xpath expr="//tr[@t-as='line']" position="after">
             <t t-if="line.formatted_note">
-                <tr style="padding:0;">
-                    <td colspan="6" style="padding:0;">
-                        <table style="width:100%;border:0;padding:0;">
-                            <caption class="formatted_note">
-                                <span t-field="line.formatted_note"/>
-                            </caption>
-                        </table>
+                <tr>
+                    <td colspan="1000">
+                       <span t-field="line.formatted_note"/>
                     </td>
                 </tr>
             </t>
-        </t>
+      </xpath>
+      <xpath expr="//tr[@t-as='line']" position="attributes">
+        <attribute name="t-as"/>
+        <attribute name="t-foreach"/>
       </xpath>
       <xpath expr="//p[@t-field='o.notes']" position="after">
         <p t-if="o.note2">


### PR DESCRIPTION
The proposed position="replace" is not a good practice and it is breaking my table when there is inheritance. Therefore I propose to add a new <t> tag and use position="move" to move the whole <tr> tag in <tbody> to the new tag. This is good for any further inheritance.