### PR TITLE
[IMP] purchase_comment_template: Avoid replace

### DIFF
--- a/purchase_comment_template/views/report_purchaseorder.xml
+++ b/purchase_comment_template/views/report_purchaseorder.xml
@@ -16,41 +16,18 @@
           <span t-field="o.note1"/>
         </p>
       </xpath>
-      <xpath expr="//tr[@t-as='line']" position="replace">
-        <t t-foreach="o.order_line" t-as="line">
-            <tr>
-                <td>
-                    <span t-field="line.name"/>
-                </td>
-                <td>
-                    <span t-esc="', '.join(map(lambda x: x.name, line.taxes_id))"/>
-                </td>
-                <td class="text-center">
-                    <span t-field="line.date_planned"/>
-                </td>
-                <td class="text-right">
-                    <span t-field="line.product_qty"/>
-                    <span t-field="line.product_uom.name" groups="uom.group_uom"/>
-                </td>
-                <td class="text-right">
-                    <span t-field="line.price_unit"/>
-                </td>
-                <td class="text-right">
-                    <span t-field="line.price_subtotal"
-                        t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+      <xpath expr="//tr[@t-as='line']" position="inside">
+        <t t-if="line.formatted_note">
+            <tr style="padding:0;">
+                <!-- Span more than existing columns to cover all the columns. -->
+                <td colspan="42" style="padding:0;">
+                    <table style="width:100%;border:0;padding:0;">
+                        <caption class="formatted_note">
+                            <span t-field="line.formatted_note"/>
+                        </caption>
+                    </table>
                 </td>
             </tr>
-            <t t-if="line.formatted_note">
-                <tr style="padding:0;">
-                    <td colspan="6" style="padding:0;">
-                        <table style="width:100%;border:0;padding:0;">
-                            <caption class="formatted_note">
-                                <span t-field="line.formatted_note"/>
-                            </caption>
-                        </table>
-                    </td>
-                </tr>
-            </t>
         </t>
       </xpath>
       <xpath expr="//p[@t-field='o.notes']" position="after">

--- a/purchase_comment_template/views/report_quotation.xml
+++ b/purchase_comment_template/views/report_quotation.xml
@@ -16,31 +16,18 @@
           <span t-field="o.note1"/>
         </p>
       </xpath>
-      <xpath expr="//tr[@t-as='order_line']" position="replace">
-        <t t-foreach="o.order_line" t-as="order_line">
-            <tr>
-                <td>
-                    <span t-field="order_line.name"/>
-                </td>
-                <td class="text-center">
-                    <span t-field="order_line.date_planned"/>
-                </td>
-                <td class="text-right">
-                    <span t-field="order_line.product_qty"/>
-                    <span t-field="order_line.product_uom" groups="uom.group_uom"/>
+      <xpath expr="//tr[@t-as='order_line']" position="inside">
+        <t t-if="order_line.formatted_note">
+            <tr style="padding:0;">
+                <!-- Span more than existing columns to cover all the columns. -->
+                <td colspan="42" style="padding:0;">
+                    <table style="width:100%;border:0;padding:0;">
+                        <caption class="formatted_note">
+                            <span t-field="order_line.formatted_note"/>
+                        </caption>
+                    </table>
                 </td>
             </tr>
-            <t t-if="order_line.formatted_note">
-                <tr style="padding:0;">
-                    <td colspan="3" style="padding:0;">
-                        <table style="width:100%;border:0;padding:0;">
-                            <caption class="formatted_note">
-                                <span t-field="order_line.formatted_note"/>
-                            </caption>
-                        </table>
-                    </td>
-                </tr>
-            </t>
         </t>
       </xpath>
       <xpath expr="//p[@t-field='o.notes']" position="after">


### PR DESCRIPTION
Steps to reproduce the error:

1. Install purchase_order_line_sequence (https://github.com/OCA/purchase-workflow/tree/82554f1c80ee730c1f4202c4a99335bb007e3c23/purchase_order_line_sequence)
2. Install purchase_comment_template
3. Print a Request for quotation

Actual:
[Request for Quotation_before.pdf](https://github.com/OCA/purchase-reporting/files/12129625/Request.for.Quotation.-.PO00001.24.pdf)
Note that the headers are not aligned with the content of their columns, and the formatted note is only covering 3 of the 4 columns.

Expected:
[Request for Quotation_after.pdf](https://github.com/OCA/purchase-reporting/files/12129651/Request.for.Quotation.-.PO00001.25.pdf) (printed using this PR)
The headers are aligned with the content of their columns, and the formatted note covers all the columns.
