### PR TITLE
[14.0] Add module Purchase Requisition Blanket Order Report

### DIFF
--- a/purchase_requisition_blanket_order_report/README.rst
+++ b/purchase_requisition_blanket_order_report/README.rst
@@ -1,0 +1,11 @@
+=========================================
+Purchase Requisition Blanket Order Report
+=========================================
+
+This module backports the Blanket order report feature from Odoo v15.0.
+
+In v14.0 the report from purchase requisition module is meant to be used only for
+call for tenders although it could be used for Blanket orders as well.
+
+This module changes the title printed on the report according to agreement type,
+and displays the price unit on the lines in case the type is a blanket order.

--- a/purchase_requisition_blanket_order_report/__manifest__.py
+++ b/purchase_requisition_blanket_order_report/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Purchase Requisition Blanket Order Report",
+    "summary": "Improvement of call for tenders report for blanket orders",
+    "version": "14.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Uncategorized",
+    "website": "https://github.com/OCA/purchase-reporting",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["grindtildeath"],
+    "license": "AGPL-3",
+    "depends": [
+        "purchase_requisition",
+    ],
+    "data": [
+        "report/report_purchase_requisition.xml",
+    ],
+}

--- a/purchase_requisition_blanket_order_report/readme/CONTRIBUTORS.md
+++ b/purchase_requisition_blanket_order_report/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/purchase_requisition_blanket_order_report/readme/DESCRIPTION.md
+++ b/purchase_requisition_blanket_order_report/readme/DESCRIPTION.md
@@ -1,0 +1,7 @@
+This module backports the Blanket order report feature from Odoo v15.0.
+
+In v14.0 the report from purchase requisition module is meant to be used only for
+call for tenders although it could be used for Blanket orders as well.
+
+This module changes the title printed on the report according to agreement type,
+and displays the price unit on the lines in case the type is a blanket order.

--- a/purchase_requisition_blanket_order_report/report/report_purchase_requisition.xml
+++ b/purchase_requisition_blanket_order_report/report/report_purchase_requisition.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="report_purchaserequisitions"
+        inherit_id="purchase_requisition.report_purchaserequisitions"
+    >
+        <!-- pylint:disable=xml-dangerous-qweb-replace-low-priority -->
+        <xpath expr="//div[hasclass('page')]/h2" position="replace">
+            <h2><span t-esc="o.type_id.name" /> <span t-field="o.name" /></h2>
+        </xpath>
+        <xpath
+            expr="//div[hasclass('page')]/div[hasclass('row')]/div[span[@t-field='o.name']]/strong"
+            position="replace"
+        >
+            <strong><span t-esc="o.type_id.name" /> Reference:</strong>
+        </xpath>
+        <xpath
+            expr="//div[hasclass('page')]/t[@t-if='o.line_ids']/table/thead/tr/th[@groups='uom.group_uom']"
+            position="after"
+        >
+            <th
+                t-if="o.type_id == env.ref('purchase_requisition.type_single')"
+            >Price Unit</th>
+        </xpath>
+        <xpath
+            expr="//div[hasclass('page')]/t[@t-if='o.line_ids']/table/tbody/tr/t/td[@groups='uom.group_uom']"
+            position="after"
+        >
+            <td t-if="o.type_id == env.ref('purchase_requisition.type_single')">
+                <span
+                    t-field="line_ids.price_unit"
+                    t-options='{"widget": "monetary", "display_currency": line_ids.requisition_id.currency_id}'
+                />
+            </td>
+        </xpath>
+    </template>
+</odoo>

--- a/setup/purchase_requisition_blanket_order_report/odoo/addons/purchase_requisition_blanket_order_report
+++ b/setup/purchase_requisition_blanket_order_report/odoo/addons/purchase_requisition_blanket_order_report
@@ -1,0 +1,1 @@
+../../../../purchase_requisition_blanket_order_report

--- a/setup/purchase_requisition_blanket_order_report/setup.py
+++ b/setup/purchase_requisition_blanket_order_report/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module backports the Blanket order report feature from Odoo v15.0.

In v14.0 the report from purchase requisition module is meant to be used only for
call for tenders although it could be used for Blanket orders as well.

This module changes the title printed on the report according to agreement type,
and displays the price unit on the lines in case the type is a blanket order.
