### PR TITLE
[14.0] dotfiles update needs manual intervention

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,8 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.18
+_commit: v1.21.1
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
+convert_readme_fragments_to_markdown: false
 generate_requirements_txt: true
 github_check_license: true
 github_ci_extra_env: {}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale PRs and issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # General settings.
@@ -48,7 +48,7 @@ jobs:
       # * Issues that are pending more information
       # * Except Issues marked as "no stale"
       - name: Needs more information stale issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,9 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update .pot files
         run: oca_export_and_push_pot https://x-access-token:${{ secrets.GIT_PUSH_TOKEN }}@github.com/${{ github.repository }}
         if: ${{ matrix.makepot == 'true' && github.event_name == 'push' && github.repository_owner == 'OCA' }}

--- a/.oca_hooks.cfg
+++ b/.oca_hooks.cfg
@@ -1,0 +1,2 @@
+[MESSAGES_CONTROL]
+disable=xml-deprecated-data-node,xml-deprecated-tree-attribute

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,11 +113,7 @@ repos:
       - id: check-symlinks
       - id: check-xml
       - id: mixed-line-ending
-<<<<<<< before updating
-        args: ["--fix=lf"] # ruff doesn't support python 3.6
-=======
         args: ["--fix=lf"]
->>>>>>> after updating
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ exclude: |
   readme/.*\.(rst|md)$|
   # Ignore build and dist directories in addons
   /build/|/dist/|
+  # Ignore test files in addons
+  /tests/samples/.*|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
@@ -37,7 +39,7 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
   - repo: https://github.com/oca/maintainer-tools
-    rev: 568cacd1d6eef453063a524a5ce63dcd49c7259b
+    rev: 9a170331575a265c092ee6b24b845ec508e8ef75
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -50,6 +52,7 @@ repos:
           - --org-name=OCA
           - --repo-name=purchase-reporting
           - --if-source-changed
+          - --keep-source-digest
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
     rev: v0.0.25
     hooks:
@@ -110,7 +113,11 @@ repos:
       - id: check-symlinks
       - id: check-xml
       - id: mixed-line-ending
+<<<<<<< before updating
         args: ["--fix=lf"] # ruff doesn't support python 3.6
+=======
+        args: ["--fix=lf"]
+>>>>>>> after updating
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
     hooks:


### PR DESCRIPTION
Dear maintainer,

After updating the dotfiles, `pre-commit run -a`
fails in a manner that cannot be resolved automatically.

Can you please have a look, fix and merge?

Thanks,

Handled by @Tecnativa 