### PR TITLE
[FIX] [16.0] purchase_packaging_report: Do not cut packaging text on reports

### DIFF
--- a/purchase_packaging_report/report/purchase_order_templates.xml
+++ b/purchase_packaging_report/report/purchase_order_templates.xml
@@ -9,6 +9,7 @@
                 t-if="line.product_packaging_id"
                 groups="product.group_stock_packaging"
                 class="text-secondary"
+                style="white-space: nowrap;"
             >
                 <span t-field="line.product_packaging_id" />:
                 <span t-field="line.product_packaging_qty" />

--- a/purchase_packaging_report/report/purchase_quotation_templates.xml
+++ b/purchase_packaging_report/report/purchase_quotation_templates.xml
@@ -9,6 +9,7 @@
                 t-if="order_line.product_packaging_id"
                 groups="product.group_stock_packaging"
                 class="text-secondary"
+                style="white-space: nowrap;"
             >
                 <span t-field="order_line.product_packaging_id" />:
                 <span t-field="order_line.product_packaging_qty" />


### PR DESCRIPTION
Do not cut packaging text on reports (RFQ and Purchase)

# Before
![image](https://github.com/OCA/purchase-reporting/assets/1162050/b6d2567e-532f-4f0a-8b32-990e785781e6)

# After
![image](https://github.com/OCA/purchase-reporting/assets/1162050/e04b9606-41af-473c-bee7-73c3bf73c41b)

MT-6143 @moduon @rafaelbn @Gelojr  @fcvalgar @EmilioPascual please review if you want :)