### PR TITLE
[15.0][FIX] purchase_comment_template: fix action to allow to see templates in purchases

### DIFF
--- a/purchase_comment_template/views/base_comment_template_view.xml
+++ b/purchase_comment_template/views/base_comment_template_view.xml
@@ -5,8 +5,8 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.comment.template</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('models', '=', 'purchase.order')]</field>
-        <field name="context" eval="{'default_models': 'purchase.order'}" />
+        <field name="domain">[('model_ids', '=', 'purchase.order')]</field>
+        <field name="context">{'default_models': 'purchase.order'}</field>
         <field
             name="view_id"
             ref="base_comment_template.view_base_comment_template_tree"


### PR DESCRIPTION
Steps to reproduce:

Issue 1: Create a comment template for purchase.order (among other models) using the menu in the main settings Odoo menu (settings > technical > reporting). Then go to Purchase > Configuration > Document Comments. You cannot see the comment you created.

Issue 2: Create a new comment from this menu. The default model 'purchase.order' is not set

@ForgeFlow

