### PR TITLE
[18.0][FIX] purchase_comment_template: fix comment_template_bottom position

### DIFF
--- a/purchase_comment_template/views/report_purchaseorder.xml
+++ b/purchase_comment_template/views/report_purchaseorder.xml
@@ -16,13 +16,13 @@
                 <div t-out="comment_template_top.text" />
             </t>
         </div>
-        <p t-field="o.notes" position="after">
+        <span t-field="o.payment_term_id" position="after">
             <t
                 t-foreach="o.comment_template_ids.filtered(lambda x: x.position == 'after_lines')"
                 t-as="comment_template_bottom"
             >
                 <div t-out="comment_template_bottom.text" />
             </t>
-        </p>
+        </span>
     </template>
 </odoo>


### PR DESCRIPTION
**The issue:** we are inserting comment_template_bottom before the element <strong>Payment Terms</strong>. Causing a weird report where the last page element is 'Payment Terms:'

<img width="951" height="683" alt="Untitled Diagram drawio" src="https://github.com/user-attachments/assets/600618c1-7bfc-47ac-bbda-58a44a0215b2" />
